### PR TITLE
corrected # of attribute fields in coding parser; extra arg in Sequen…

### DIFF
--- a/plugins/sequence/src/org/biomart/processors/sequence/CodingParser.java
+++ b/plugins/sequence/src/org/biomart/processors/sequence/CodingParser.java
@@ -49,7 +49,7 @@ public class CodingParser extends SequenceParser {
 
     private HashSet<String> seqEdit = new HashSet<String>();
 
-    public CodingParser() { this(false, 12); }
+    public CodingParser() { this(false, 14); }
     public CodingParser(boolean isProtein, int i) {
         super(i);
         this.isProtein = isProtein;

--- a/plugins/sequence/src/org/biomart/processors/sequence/Sequence.java
+++ b/plugins/sequence/src/org/biomart/processors/sequence/Sequence.java
@@ -34,28 +34,28 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  *
  */
 public class Sequence extends ProcessorImpl implements SequenceConstants {
-    private Connection conn = null;
+    protected Connection conn = null;
 
     // Parser lookup map
-    private static final Map<String,Class<? extends SequenceParser>> lookup;
+    protected static final Map<String,Class<? extends SequenceParser>> lookup;
 
     // Track count
-    private int limit = Integer.MAX_VALUE;
-    private int total = 0;
-    private boolean hasResults = false;
-    private boolean isDone = false;
+    protected int limit = Integer.MAX_VALUE;
+    protected int total = 0;
+    protected boolean hasResults = false;
+    protected boolean isDone = false;
 
-    private String databaseTableName;
-    private int headerAttributes = 0;
+    protected String databaseTableName;
+    protected int headerAttributes = 0;
 
-    private SequenceParser parser;
+    protected SequenceParser parser;
 
     // Cache rows until BATCH_SIZE is reached, then do the actual sequence retrieval
-    private static final int BATCH_SIZE = 100;
-    private List<String[]> buffer = new ArrayList<String[]>();
-    private int count = 0;
+    protected static final int BATCH_SIZE = 100;
+    protected List<String[]> buffer = new ArrayList<String[]>();
+    protected int count = 0;
 
-    protected class SequenceCallback implements Function<String[],Boolean>, OutputConstants {
+    private class SequenceCallback implements Function<String[],Boolean>, OutputConstants {
         @Override
         public Boolean apply(String[] row) {
             hasResults = true;
@@ -281,7 +281,7 @@ public class Sequence extends ProcessorImpl implements SequenceConstants {
         closeSilently(conn);
     }
 
-    private void validateDatabaseSettings() {
+    protected void validateDatabaseSettings() {
         if (isNullOrEmpty(this.jdbcConnectionURL.value)) {
             this.jdbcConnectionURL.value = System.getProperty("processors.sequence.connection");
         }

--- a/plugins/sequence/src/org/biomart/processors/sequence/SequenceMain.java
+++ b/plugins/sequence/src/org/biomart/processors/sequence/SequenceMain.java
@@ -131,7 +131,7 @@ public class SequenceMain {
 
 		long timestamp1 = printTimestamp(">");
 		FileOutputStream seqOut = new FileOutputStream(new File(outputFile));
-		portal.executeQuery(xmlQuery, seqOut);
+		portal.executeQuery(xmlQuery, seqOut,false);
 		seqOut.close();
 		long timestamp2 = printTimestamp("<");
 		int timestampMin = (int)((timestamp2-timestamp1)/60000);


### PR DESCRIPTION
…ceMain

2 minor bug fixes in the sequence plugin. The number of attributes passed in the constructor of the coding parser (12) did not match the expected attributes (14), resulting in improper headers.

And there was a missing argument in the test SequenceMain.java
